### PR TITLE
Add travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "7"


### PR DESCRIPTION
It is very useful when you can see tests status. 
Here is an example: https://travis-ci.org/b17/node-koajs-rest-skeleton/builds/217106359.
It is still required to configure Travis CI manually to enable the project. 